### PR TITLE
Correct 'Widows' version

### DIFF
--- a/source/bindbc/glfw/bindstatic.d
+++ b/source/bindbc/glfw/bindstatic.d
@@ -142,7 +142,7 @@ enum bindGLFW_EGL = q{
     }
 };
 
-version(Widows) {
+version(Windows) {
     enum bindGLFW_WGL = q{
         extern(C) @nogc nothrow HGLRC glfwGetWGLContext(GLFWwindow*);
     };


### PR DESCRIPTION
I stumbled upon this, think it's a typo