### PR TITLE
Remove useless exclusion

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -24,5 +24,4 @@ configuration "static" {
 configuration "staticBC" {
     dflags "-betterC"
     versions "BindGLFW_Static"
-    excludedSourceFiles "source/bindbc/sdl/dynload.d"
 }


### PR DESCRIPTION
The file doesn't even exist in this repository, and the dynamic loading code is already versioned out in the static configuration.